### PR TITLE
Fix 2FA login flow by centralizing auth logic

### DIFF
--- a/src/uiLoginPhone.h
+++ b/src/uiLoginPhone.h
@@ -5,8 +5,6 @@
 #include <wx/simplebook.h>
 #include <wx/wx.h>
 
-wxDECLARE_EVENT(wxEVT_TDLIB_UPDATE, wxCommandEvent);
-
 class CLoginPhoneWindow : public wxPanel {
   public:
     enum ELoginState {
@@ -19,7 +17,6 @@ class CLoginPhoneWindow : public wxPanel {
 
     void OnNextPressed(wxCommandEvent& event);
     void OnCancelPressed(wxCommandEvent& event);
-    void OnTdlibUpdate(wxCommandEvent& event);
 
     void SwitchLoginState(const ELoginState& newState);
 


### PR DESCRIPTION
The application was getting stuck during 2FA login because the authorization update for the password prompt was being ignored.

This was caused by the main frame's update callback overwriting the login phone window's callback.

This commit centralizes the authorization state handling in the CMainFrame class. CMainFrame now receives all authorization updates and delegates UI changes to the appropriate window. This ensures that the `authorizationStateWaitPassword` state is handled correctly, allowing you to enter your 2FA password and complete the login.